### PR TITLE
Revert 4-vector to RAW, perform puppi computation in fastjetfinder, merger modules #

### DIFF
--- a/external/PUPPI/PuppiContainer.cc
+++ b/external/PUPPI/PuppiContainer.cc
@@ -185,8 +185,8 @@ const std::vector<double> PuppiContainer::puppiWeights() {
     //Now get rid of the thrown out weights for the particle collection
     // if(pWeight == 0) continue;
       //Produce
-    fastjet::PseudoJet curjet( pWeight*fPFParticles[i0].px(), pWeight*fPFParticles[i0].py(), pWeight*fPFParticles[i0].pz(), pWeight*fPFParticles[i0].e());
-    //fastjet::PseudoJet curjet( fPFParticles[i0].px(), fPFParticles[i0].py(), fPFParticles[i0].pz(), fPFParticles[i0].e());
+    //fastjet::PseudoJet curjet( pWeight*fPFParticles[i0].px(), pWeight*fPFParticles[i0].py(), pWeight*fPFParticles[i0].pz(), pWeight*fPFParticles[i0].e());
+    fastjet::PseudoJet curjet( fPFParticles[i0].px(), fPFParticles[i0].py(), fPFParticles[i0].pz(), fPFParticles[i0].e());
     curjet.set_user_index(i0);//fRecoParticles[i0].id);
     fPupParticles.push_back(curjet);
   }


### PR DESCRIPTION
Revert commented-out code to use modified weight calculation for PseudoJet.